### PR TITLE
Use more up to date dependency versions.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,9 +5,9 @@
     "require": {
         "php": ">=5.3.3",
         "symfony/symfony": "2.3.*",
-        "doctrine/orm": ">=2.2.3,<=2.4-dev",
-        "doctrine/doctrine-bundle": "1.2.*",
-        "doctrine/doctrine-fixtures-bundle": "dev-master",
+        "doctrine/orm": "~2.2,>=2.2.3,<2.5",
+        "doctrine/doctrine-bundle": "~1.2",
+        "doctrine/doctrine-fixtures-bundle": "2.2.0",
         "stof/doctrine-extensions-bundle": "v1.1.0"
     },
 


### PR DESCRIPTION
This matches some of the deps versions as listed in the Symfony Standard Edition. It doesn't update the required version of Symfony however (maybe one for later).